### PR TITLE
use Promise.all

### DIFF
--- a/packages/react-app/src/components/TokenImportDisplay.jsx
+++ b/packages/react-app/src/components/TokenImportDisplay.jsx
@@ -23,9 +23,7 @@ export default function TokenImportDisplay({ tokenSettingsHelper, tokenCoreDispl
 
                 setLoading(true);
 
-                // ToDo: Use Promise.all to make this faster
-                const decimals = await tokenHelper.decimals();
-                const symbol = await tokenHelper.symbol();
+                const [decimals, symbol] = await Promise.all([tokenHelper.decimals(),tokenHelper.symbol()])
 
                 setLoading(false);
 


### PR DESCRIPTION
This is a small fix for using Promise.all instead of separated promises, so it will take as much time as the longest call.